### PR TITLE
Allow filtering of ICE candidates

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,11 @@ module.exports = function(pc, opts) {
 
   function applyCandidate(task, next) {
     var data = task.args[0];
+    // Allow selective filtering of ICE candidates
+    if (opts && opts.filterCandidate && !opts.filterCandidate(data)) {
+      tq('ice.remote.filtered', candidate);
+      return next();
+    }
     var candidate = data && data.candidate && createIceCandidate(data);
 
     function handleOk() {


### PR DESCRIPTION
Allows the passing of a filterCandidate function in the options that when provided should return true/false indicating if a candidate should be applied or not.

Useful for enforcing ICE candidate preferences (such as UDP only, TURN only, etc)