### PR TITLE
Optimize queue by reducing time spent adding ICE candidates

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = function(pc, opts) {
 
   // initialise task importance
   var priorities = (opts || {}).priorities || DEFAULT_PRIORITIES;
-  var queueInterval = (opts || {}).interval || 50;
+  var queueInterval = (opts || {}).interval || 10;
 
   // check for plugin usage
   var plugin = findPlugin((opts || {}).plugins);

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run queue-test && npm run quickconnect-test",
-    "queue-test": "browserify -t brfs test/all.js | broth start",
-    "quickconnect-test": "cd ./node_modules/rtc-quickconnect/node_modules/rtc-tools; npm link ../../../../; cd ../../../../; browserify -t brfs test/quickconnect-test.js | broth start | tap-spec",
+    "queue-test": "browserify -t brfs test/all.js | broth start-$BROWSER",
+    "quickconnect-test": "cd ./node_modules/rtc-quickconnect/node_modules/rtc-tools; npm link ../../../../; cd ../../../../; browserify -t brfs test/quickconnect-test.js | broth start-$BROWSER | tap-spec",
     "gendocs": "gendocs > README.md"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An asynchronous task queue that applies actions to an RTCPeerConnection in the most sensible order",
   "main": "index.js",
   "scripts": {
-    "test": "browserify -t brfs test/all.js | broth start | tap-spec && npm run quickconnect-test",
+    "test": "npm run queue-test && npm run quickconnect-test",
+    "queue-test": "browserify -t brfs test/all.js | broth start",
     "quickconnect-test": "cd ./node_modules/rtc-quickconnect/node_modules/rtc-tools; npm link ../../../../; cd ../../../../; browserify -t brfs test/quickconnect-test.js | broth start | tap-spec",
     "gendocs": "gendocs > README.md"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An asynchronous task queue that applies actions to an RTCPeerConnection in the most sensible order",
   "main": "index.js",
   "scripts": {
-    "test": "browserify -t brfs test/all.js | broth start-$BROWSER | tap-spec",
+    "test": "browserify -t brfs test/all.js | broth start | tap-spec",
     "gendocs": "gendocs > README.md"
   },
   "repository": {
@@ -38,7 +38,7 @@
     "rtc-core": "^4.0.0",
     "tap-spec": "^3.0.0",
     "tape": "^4.0.0",
-    "travis-multirunner": "^2.0.9"
+    "travis-multirunner": "^2.7.0"
   },
   "testling": {
     "files": "test/all.js"

--- a/test/data-candidate.js
+++ b/test/data-candidate.js
@@ -103,16 +103,14 @@ test('can set the remote description of the pc (2 mlines)', function(t) {
   );
 });
 
-test('a queue wrapped version of the peer connection will not apply the data candidate', function(t) {
-  var successTimer = setTimeout(t.pass, 1000);
-
+test('a queue wrapped version of the peer connection with no data mid will not apply the data candidate', function(t) {
   t.plan(2);
   t.ok(pc = queue(pc));
 
   pc.once('ice.remote.applied', function() {
-    clearTimeout(successTimer);
     t.fail('candidate should not have been applied');
   });
+  pc.once('task.expire', t.pass);
 
   pc.addIceCandidate(new RTCIceCandidate(candidateData));
 });
@@ -123,26 +121,14 @@ test('can create a new peer connection', function(t) {
 });
 
 test('can set the remote description of the pc (3 mlines)', function(t) {
-  t.plan(1);
-  pc.setRemoteDescription(
-    new RTCSessionDescription({ type: 'offer', sdp: sdp.all }),
-    t.pass,
-    t.fail
-  );
+  t.plan(2);  
+  t.ok(pc = queue(pc));
+  pc.once('negotiate.setremotedesc.ok', t.pass);
+  pc.setRemoteDescription({ type: 'offer', sdp: sdp.all });
 });
 
 test('a queue wrapped version of the peer connection will apply the data candidate', function(t) {
-  t.plan(2);
-  t.ok(pc = queue(pc));
-
-  pc.once('ice.remote.applied', t.pass);
-  pc.addIceCandidate(new RTCIceCandidate(candidateData));
-});
-
-test('a queue wrapped version of the peer connection will apply the data candidate when set to always parse SDP', function(t) {
-  t.plan(2);
-  t.ok(pc = queue(pc, { sdpParseMode: 'always' }));
-
+  t.plan(1);
   pc.once('ice.remote.applied', t.pass);
   pc.addIceCandidate(new RTCIceCandidate(candidateData));
 });

--- a/test/optimizations.js
+++ b/test/optimizations.js
@@ -1,0 +1,94 @@
+var test = require('tape');
+var taskqueue = require('..');
+var RTCPeerConnection = require('rtc-core/detect')('RTCPeerConnection');
+var waitConnected = require('rtc-core/wait-connected');
+var connections = [];
+var queues = [];
+var offerSdp;
+var answerSdp;
+
+// require('cog/logger').enable('*');
+
+function timeout(fn, opts) {
+  opts = opts || {};
+  return setTimeout(function() { 
+    fn(opts.message || 'timed out');
+  }, opts.delay || 1000);
+}
+
+test('can create connection:0', function(t) {
+  t.plan(1);
+  t.ok(connections[0] = new RTCPeerConnection({ iceServers: [] }));
+});
+
+test('can create connection:1', function(t) {
+  t.plan(1);
+  t.ok(connections[1] = new RTCPeerConnection({ iceServers: [] }));
+});
+
+test('can wrap the connections in queues', function(t) {
+  t.plan(2);
+  queues = connections.map(function(conn) {
+    return taskqueue(conn, {
+      interval: 1,
+      sdpfilter: function(sdp) {
+        return sdp;
+      }
+    });
+  });
+
+  t.ok(queues[0]);
+  t.ok(queues[1]);
+});
+
+test('create a datachannel on connection:0 (required by moz)', function(t) {
+  t.plan(1);
+  connections[0].createDataChannel('test');
+  t.pass('created data channel');
+});
+
+test('can create an offer using queue:0', function(t) {
+  t.plan(1);
+  queues[0].once('sdp.local', function(sdp) {
+    t.ok(sdp, 'got sdp');
+    offerSdp = sdp;
+  });
+
+  queues[0].createOffer();
+});
+
+test('can setRemoteDescription on connection:1', function(t) {
+  t.plan(1);
+  queues[1].once('sdp.local', function(sdp) {
+    answerSdp = sdp;
+    t.ok(sdp, 'got sdp');
+  });
+
+  queues[1].setRemoteDescription(offerSdp);
+});
+
+test('can queue up lots of ICE candidates and process quickly (originally ~55-60ms per candidate)', function(t) {
+  var failTimer = timeout(t.fail);
+  var start = Date.now();
+  var expected = 100, actual = 0;
+  queues[0].on('ice.remote.applied', function() {
+    actual++;
+    if (expected == actual) {
+      clearTimeout(failTimer);
+      console.log('Took %d ms to add %d candidates. Avg %d ms / candidate', Date.now() - start, expected, (Date.now() - start) / expected);
+      return t.pass('All candidates added');
+    }
+  });
+
+  for (var i = 0; i < expected; i++) {
+    queues[0].addIceCandidate({ sdpMid: '', candidate: 'candidate:3391358738 1 udp 2122197247 2402:1800:f:6101:a5a3:613f:17c3:38d 63438 typ host generation 0'});
+  }
+})
+
+test('can setRemoteDescription on connection:0', function(t) {
+  t.plan(2);
+  waitConnected(connections[0], t.pass.bind(t, 'connection:0 connected'));
+  waitConnected(connections[1], t.pass.bind(t, 'connection:1 connected'));
+
+  queues[0].setRemoteDescription(answerSdp);
+});


### PR DESCRIPTION
Introduces an `immediate` option for tasks that indicates that upon completion of the task it should immediately recheck the queue - save a significant amount of time when adding ICE candidates.

Minor tweaks like predetermining the createIceCandidate and createSessionDescription functions, and setting a lower default interval.