### PR TITLE
Set __mediaTypes to undefined as opposed to delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,8 @@ module.exports = function(pc, opts) {
   function completeConnection() {
     // Clean any cached media types now that we have potentially new remote description
     if (pc.__mediaTypes) {
-      delete pc.__mediaTypes;
+      // Set defined as opposed to delete, for compatibility purposes
+      pc.__mediaTypes = undefined;
     }
 
     if (VALID_RESPONSE_STATES.indexOf(pc.signalingState) >= 0) {


### PR DESCRIPTION
Attempt to use delete in `pc.__mediaTypes` throws an error when using the Temasys plugin.