### PR TITLE
Compliance with Firefox 43+

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mbus": "^2.0.0",
     "priorityqueuejs": "^1.0.0",
     "rtc-core": "^4.0.0",
-    "rtc-sdp": "^1.1.0",
+    "rtc-sdp": "^1.2.0",
     "rtc-sdpclean": "^1.0.0",
     "rtc-validator": "^1.0.0",
     "whisk": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rtc-switchboard": "^3.0.0",
     "tap-spec": "^3.0.0",
     "tape": "^4.0.0",
-    "travis-multirunner": "^2.7.0"
+    "travis-multirunner": "^3.0.0"
   },
   "testling": {
     "files": "test/all.js"


### PR DESCRIPTION
Updates a couple of things that break with Firefox 43+

1. Firefox no longer accepts the Chrome style constraints keys, so if Firefox is detected, use the updated keys.
2. Checks ICE candidates for validity against both media types and IDs, as Firefox is using it's media stream bundling.