### PR TITLE
Use `sdp-interop`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "rtc-sdp": "^1.2.0",
     "rtc-sdpclean": "^1.0.0",
     "rtc-validator": "^1.0.0",
+    "sdp-interop": "^0.1.11",
     "whisk": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**This is more of a request for comment than a serious PR**

Uses the [`sdp-interop`](https://github.com/jitsi/sdp-interop) module from Jitsi to provide some greater multi stream interoperability between Chrome and Firefox. I'm not necessarily sold on this in it's current state, as it doesn't seem to provide any real benefits to the use cases I'm trying with, but I though I'd throw it out there for wider thoughts.

Requires the changes from https://github.com/jitsi/sdp-interop/compare/issue-13 to be applied to `sdp-interop` if you are using data channels.
